### PR TITLE
fix typo in popper.js

### DIFF
--- a/docs/static/vendor/node_modules/popper.js/dist/esm/popper.js
+++ b/docs/static/vendor/node_modules/popper.js/dist/esm/popper.js
@@ -2285,7 +2285,7 @@ var modifiers = {
 
 /**
  * Default options provided to Popper.js constructor.<br />
- * These can be overriden using the `options` argument of Popper.js.<br />
+ * These can be overridden using the `options` argument of Popper.js.<br />
  * To override an option, simply pass as 3rd argument an object with the same
  * structure of this object, example:
  * ```


### PR DESCRIPTION
overriden -> overridden